### PR TITLE
Filter out cancelled events from calendar feeds

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,12 @@ async function serveCalendar(request, env, calendarId, forceText = false) {
 
   let events = eventsData.collection.items;
 
+  // Filter out cancelled events
+  events = events.filter(event => {
+    const isCanceled = event.data?.find(d => d.name === 'is_canceled')?.value;
+    return !isCanceled;
+  });
+
   // Apply filter
   if (filterType === 'games') {
     events = events.filter(event => {


### PR DESCRIPTION
Added a filter to exclude events where is_canceled is true, preventing cancelled events from appearing in the calendar feed.

Fixes #2 via [Claude Code](https://claude.ai/code)