### PR TITLE
Add stale token detection, auto-logout on invalid tokens, and /logout endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ Try the [CalSnap settings demo](https://andesco.github.io/calsnap/) to see how y
 
 &nbsp;
 
+## Authentication
+
+CalSnap uses TeamSnap OAuth. On first visit the worker redirects you to TeamSnap to authorize, then stores tokens in Cloudflare KV.
+
+- **Login:** visit the root URL — you'll be redirected to TeamSnap automatically.
+- **Logout:** visit `/logout` to clear your session and restart the OAuth flow.
+
+If your tokens become stale or are revoked by TeamSnap, the worker detects the invalid 401 response, clears the stored tokens, and redirects you back to the login flow automatically.
+
+&nbsp;
+
 ## Required Environment Variables
 
 - **`ALLOWED_USER_EMAIL`**

--- a/assets/settings.html
+++ b/assets/settings.html
@@ -372,6 +372,11 @@
                 const response = await fetch('/api/teams');
                 const data = await response.json();
 
+                if (response.status === 401 || data.auth_required) {
+                    window.location.href = '/';
+                    return;
+                }
+
                 if (data.error) {
                     throw new Error(data.error);
                 }

--- a/index.js
+++ b/index.js
@@ -491,6 +491,10 @@ async function fetchTeamSnapData(endpoint, env) {
           'Accept': 'application/json',
         },
       });
+      if (retryResponse.status === 401) {
+        await clearAuthTokens(env);
+        return null;
+      }
       return retryResponse.ok ? await retryResponse.json() : null;
     }
     return null;
@@ -502,10 +506,19 @@ async function fetchTeamSnapData(endpoint, env) {
 /**
  * Refreshes the access token using the refresh token.
  */
+async function clearAuthTokens(env) {
+  await Promise.all([
+    env[KV_NAMESPACE].delete('oauth_access_token'),
+    env[KV_NAMESPACE].delete('oauth_refresh_token'),
+    env[KV_NAMESPACE].delete('oauth_expires_at'),
+  ]);
+}
+
 async function refreshAccessToken(env) {
   const refreshToken = await env[KV_NAMESPACE].get('oauth_refresh_token');
   if (!refreshToken) {
     console.log('No refresh token available');
+    await clearAuthTokens(env);
     return null;
   }
 
@@ -543,10 +556,12 @@ async function refreshAccessToken(env) {
       return tokenData;
     } else {
       console.error('Token refresh failed:', response.status);
+      await clearAuthTokens(env);
       return null;
     }
   } catch (error) {
     console.error('Error refreshing token:', error);
+    await clearAuthTokens(env);
     return null;
   }
 }
@@ -677,7 +692,7 @@ async function handleApiRequest(request, env) {
 
   // Check authentication for API requests
   if (!(await isAuthenticated(env))) {
-    return new Response(JSON.stringify({ error: 'Not authenticated' }), {
+    return new Response(JSON.stringify({ error: 'Not authenticated', auth_required: true }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' }
     });
@@ -701,7 +716,14 @@ async function handleTeamsApi(request, env) {
   try {
     const userData = await fetchTeamSnapData('/me', env);
 
-    if (!userData || !userData.collection || !userData.collection.items || !userData.collection.items[0]) {
+    if (!userData) {
+      return new Response(JSON.stringify({ error: 'Not authenticated', auth_required: true }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    if (!userData.collection || !userData.collection.items || !userData.collection.items[0]) {
       return new Response(JSON.stringify({ error: 'User data not found' }), {
         status: 500,
         headers: { 'Content-Type': 'application/json' }
@@ -893,6 +915,12 @@ export default {
     // Handle OAuth callback
     if (path === '/auth-callback') {
       return handleOAuthCallback(request, env);
+    }
+
+    // Handle logout
+    if (path === '/logout') {
+      await clearAuthTokens(env);
+      return startOAuth(request, env);
     }
 
     // Handle root page - smart routing

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ const TEAMSNAP_OAUTH_URL = 'https://auth.teamsnap.com/oauth/authorize';
 const TEAMSNAP_TOKEN_URL = 'https://auth.teamsnap.com/oauth/token';
 const TEAMSNAP_API_URL = 'https://api.teamsnap.com/v3';
 
+// Thrown by fetchTeamSnapData when tokens are missing or rejected by TeamSnap.
+// Distinct from a null return, which signals a non-auth API failure.
+class AuthError extends Error {}
+
 // =============================================================================
 // CALENDAR GENERATION FUNCTIONS (PRESERVED FROM ORIGINAL)
 // =============================================================================
@@ -470,7 +474,7 @@ async function fetchTeamSnapData(endpoint, env) {
     if (newTokens) {
       accessToken = newTokens.access_token;
     } else {
-      return null;
+      throw new AuthError('No valid access token');
     }
   }
 
@@ -482,7 +486,7 @@ async function fetchTeamSnapData(endpoint, env) {
   });
 
   if (response.status === 401) {
-    console.log('Token expired, attempting refresh...');
+    console.log('Token rejected, attempting refresh...');
     const newTokens = await refreshAccessToken(env);
     if (newTokens) {
       const retryResponse = await fetch(`${TEAMSNAP_API_URL}${endpoint}`, {
@@ -493,11 +497,11 @@ async function fetchTeamSnapData(endpoint, env) {
       });
       if (retryResponse.status === 401) {
         await clearAuthTokens(env);
-        return null;
+        throw new AuthError('Token invalid after refresh');
       }
       return retryResponse.ok ? await retryResponse.json() : null;
     }
-    return null;
+    throw new AuthError('Token refresh failed');
   }
 
   return response.ok ? await response.json() : null;
@@ -716,13 +720,6 @@ async function handleTeamsApi(request, env) {
   try {
     const userData = await fetchTeamSnapData('/me', env);
 
-    if (!userData) {
-      return new Response(JSON.stringify({ error: 'Not authenticated', auth_required: true }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
     if (!userData.collection || !userData.collection.items || !userData.collection.items[0]) {
       return new Response(JSON.stringify({ error: 'User data not found' }), {
         status: 500,
@@ -801,6 +798,12 @@ async function handleTeamsApi(request, env) {
     });
 
   } catch (error) {
+    if (error instanceof AuthError) {
+      return new Response(JSON.stringify({ error: 'Not authenticated', auth_required: true }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
     console.error('Teams API error:', error);
     return new Response(JSON.stringify({ error: 'Failed to fetch teams' }), {
       status: 500,
@@ -862,10 +865,14 @@ async function handleTeamSettingsApi(request, env) {
 
     // Invalidate cached calendars when settings change
     // We need to get the team name to regenerate tokens
-    const teamData = await fetchTeamSnapData(`/teams/${teamId}`, env);
     let teamName = null;
-    if (teamData && teamData.collection && teamData.collection.items && teamData.collection.items.length > 0) {
-      teamName = teamData.collection.items[0].data.find(d => d.name === 'name').value;
+    try {
+      const teamData = await fetchTeamSnapData(`/teams/${teamId}`, env);
+      if (teamData?.collection?.items?.length > 0) {
+        teamName = teamData.collection.items[0].data.find(d => d.name === 'name').value;
+      }
+    } catch {
+      // Cache invalidation is best-effort; don't fail the settings save
     }
 
     if (teamName) {

--- a/index.js
+++ b/index.js
@@ -720,7 +720,7 @@ async function handleTeamsApi(request, env) {
   try {
     const userData = await fetchTeamSnapData('/me', env);
 
-    if (!userData.collection || !userData.collection.items || !userData.collection.items[0]) {
+    if (!userData || !userData.collection || !userData.collection.items || !userData.collection.items[0]) {
       return new Response(JSON.stringify({ error: 'User data not found' }), {
         status: 500,
         headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
- Add clearAuthTokens() helper that wipes all three oauth KV keys at once
- Call clearAuthTokens in refreshAccessToken on failure so stale tokens don't persist
- Call clearAuthTokens in fetchTeamSnapData when a post-refresh 401 still occurs
- Add /logout route that clears tokens then restarts OAuth flow
- Return auth_required flag on 401 API responses so the frontend can distinguish auth errors from other errors
- Propagate 401 from handleTeamsApi when fetchTeamSnapData returns null (cleared tokens)
- settings.html: redirect to / on 401 instead of silently falling into preview mode

https://claude.ai/code/session_01Vr3os5AT9m4Qj7ap5PxH1s